### PR TITLE
Added features for easier support for add-ons in consuming projects

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk17
+  - openjdk24

--- a/src/main/java/net/buildtheearth/terraminusminus/generator/ChunkDataLoader.java
+++ b/src/main/java/net/buildtheearth/terraminusminus/generator/ChunkDataLoader.java
@@ -23,6 +23,16 @@ public class ChunkDataLoader extends CacheLoader<ChunkPos, CompletableFuture<Cac
 		this.bakers = EarthGeneratorPipelines.dataBakers(settings);
 	}
 
+    /**
+     * Construct a new ChunkDataLoader manually with custom generator datasets and data bakers
+     * @param datasets Datasets that the ChunkDataLoader should use to retreat data
+     * @param bakers Data bakers which get executed for each chunk
+     */
+    public ChunkDataLoader(@NonNull GeneratorDatasets datasets, @NonNull IEarthDataBaker<?>[] bakers) {
+        this.datasets = datasets;
+        this.bakers = bakers;
+    }
+
 	@Override
 	public CompletableFuture<CachedChunkData> load(@NonNull ChunkPos pos) {
 		return IEarthAsyncPipelineStep.getFuture(pos, this.datasets, this.bakers, CachedChunkData::builder);

--- a/src/main/java/net/buildtheearth/terraminusminus/generator/EarthBiomeProvider.java
+++ b/src/main/java/net/buildtheearth/terraminusminus/generator/EarthBiomeProvider.java
@@ -28,6 +28,17 @@ public class EarthBiomeProvider {
     }
 
     /**
+     * Construct a biome provider that uses custom biome filters which use custom datasets to provide the biomes per chunk
+     * @param datasets Datasets that the EarthBiomeProvider should use to retreat data
+     * @param filters Biome filters which get executed for each chunk
+     */
+    public EarthBiomeProvider(@NonNull GeneratorDatasets datasets, @NonNull IEarthBiomeFilter<?>[] filters) {
+        this.cache = CacheBuilder.newBuilder()
+                .weakValues()
+                .build(new ChunkDataLoader(datasets, filters));
+    }
+
+    /**
      * @deprecated this method is blocking, use {@link #getBiomesForChunkAsync(ChunkPos)}
      */
     @Deprecated
@@ -132,6 +143,16 @@ public class EarthBiomeProvider {
         public ChunkDataLoader(@NonNull EarthGeneratorSettings settings) {
             this.datasets = settings.datasets();
             this.filters = EarthGeneratorPipelines.biomeFilters(settings);
+        }
+
+        /**
+         * Construct a ChunkDataLoader that uses custom biome filters which use custom datasets to provide the biomes per chunk
+         * @param datasets Datasets that the ChunkDataLoader should use to retreat data
+         * @param filters Biome filters which get executed for each chunk
+         */
+        public ChunkDataLoader(@NonNull GeneratorDatasets datasets, @NonNull IEarthBiomeFilter<?>[] filters) {
+            this.datasets = datasets;
+            this.filters = filters;
         }
 
         @Override

--- a/src/main/java/net/buildtheearth/terraminusminus/generator/GeneratorDatasets.java
+++ b/src/main/java/net/buildtheearth/terraminusminus/generator/GeneratorDatasets.java
@@ -5,6 +5,8 @@ import lombok.NonNull;
 import net.buildtheearth.terraminusminus.projection.GeographicProjection;
 import net.buildtheearth.terraminusminus.util.CustomAttributeContainer;
 
+import java.util.Map;
+
 /**
  * Wrapper class which contains all of the datasets used for generation.
  *
@@ -18,5 +20,15 @@ public class GeneratorDatasets extends CustomAttributeContainer {
         super(EarthGeneratorPipelines.datasets(settings));
 
         this.projection = settings.projection();
+    }
+
+    /**
+     * Constructs GeneratorDatasets based on a custom map of datasets and provided GeographicProjection
+     * @param datasets The custom datasets that the GeneratorDatasets hold
+     * @param projection The geographic projection that the GeneratorDatasets returns data in
+     */
+    public GeneratorDatasets(@NonNull Map<String, Object> datasets, @NonNull GeographicProjection projection) {
+        super(datasets);
+        this.projection = projection;
     }
 }

--- a/src/main/java/net/buildtheearth/terraminusminus/generator/biome/UserOverrideBiomeFilter.java
+++ b/src/main/java/net/buildtheearth/terraminusminus/generator/biome/UserOverrideBiomeFilter.java
@@ -1,0 +1,132 @@
+package net.buildtheearth.terraminusminus.generator.biome;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.ImmutableSet;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import net.buildtheearth.terraminusminus.TerraConstants;
+import net.buildtheearth.terraminusminus.generator.ChunkBiomesBuilder;
+import net.buildtheearth.terraminusminus.generator.GeneratorDatasets;
+import net.buildtheearth.terraminusminus.projection.GeographicProjection;
+import net.buildtheearth.terraminusminus.projection.OutOfProjectionBoundsException;
+import net.buildtheearth.terraminusminus.substitutes.Biome;
+import net.buildtheearth.terraminusminus.substitutes.ChunkPos;
+import net.buildtheearth.terraminusminus.util.CornerBoundingBox2d;
+import net.buildtheearth.terraminusminus.util.bvh.BVH;
+import net.buildtheearth.terraminusminus.util.bvh.Bounds2d;
+import net.buildtheearth.terraminusminus.util.http.Disk;
+import net.daporkchop.lib.common.function.io.IOFunction;
+import net.daporkchop.lib.common.function.throwing.EFunction;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+/**
+ * Based on <a href="https://raw.githubusercontent.com/BuildTheEarth/terraplusplus/refs/heads/master/src/main/java/net/buildtheearth/terraplusplus/generator/biome/UserOverrideBiomeFilter.java">UserOverrideBiomeFilter.java @author DaPorkchop_</a>
+ *
+ * @author DavixDevelop
+ */
+public class UserOverrideBiomeFilter implements IEarthBiomeFilter<UserOverrideBiomeFilter.BiomeBoundingBox> {
+    protected final BVH<BiomeBoundingBox> bvh;
+
+    @SneakyThrows(IOException.class)
+    public UserOverrideBiomeFilter(@NonNull GeographicProjection projection) {
+        List<URL> configSources = new ArrayList<>();
+        configSources.add(UserOverrideBiomeFilter.class.getResource("biome_overrides.json5"));
+
+        try (Stream<Path> stream = Files.list(Files.createDirectories(Disk.configFile("biome_overrides")))) {
+            stream.filter(Files::isRegularFile)
+                    .filter(p -> p.getFileName().toString().matches(".*\\.json5?$"))
+                    .map(Path::toUri).map((EFunction<URI, URL>) URI::toURL)
+                    .forEach(configSources::add);
+        }
+
+        this.bvh = BVH.of(configSources.stream()
+                .map((IOFunction<URL, BiomeBoundingBox[]>) url -> TerraConstants.JSON_MAPPER.readValue(url, BiomeBoundingBox[].class))
+                .flatMap(Arrays::stream)
+                .toArray(BiomeBoundingBox[]::new));
+    }
+
+    @Override
+    public CompletableFuture<BiomeBoundingBox> requestData(ChunkPos pos, GeneratorDatasets datasets, Bounds2d bounds, CornerBoundingBox2d boundsGeo) throws OutOfProjectionBoundsException {
+        return CompletableFuture.supplyAsync(() -> this.bvh.getAllIntersecting(boundsGeo).stream()
+                .max(Comparator.naturalOrder())
+                .orElse(null));
+    }
+
+    @Override
+    public void bake(ChunkPos pos, ChunkBiomesBuilder builder, BiomeBoundingBox bbox) {
+        if (bbox == null) { //out of bounds, or no override at this position
+            return;
+        }
+
+        if (bbox.replace == null) { //all biomes are overridden
+            Arrays.fill(builder.state(), bbox.biome);
+        } else {
+            for (int x = 0; x < 16; x++) {
+                for (int z = 0; z < 16; z++) {
+                    if (bbox.replace.contains(builder.get(x, z))) {
+                        builder.set(x, z, bbox.biome);
+                    }
+                }
+            }
+        }
+    }
+
+    @JsonDeserialize
+    @JsonSerialize
+    @Getter
+    public static class BiomeBoundingBox implements Bounds2d, Comparable<BiomeBoundingBox> {
+        protected final Set<Biome> replace;
+        protected final Biome biome;
+
+        protected final double minX;
+        protected final double maxX;
+        protected final double minZ;
+        protected final double maxZ;
+
+        @Getter(onMethod_ = { @JsonGetter })
+        protected final double priority;
+
+        @JsonCreator
+        public BiomeBoundingBox(
+                @JsonProperty(value = "replace", required = false) Biome[] replace,
+                @JsonProperty(value = "biome", required = true) @NonNull Biome biome,
+                @JsonProperty(value = "bounds", required = true) @NonNull Bounds2d bounds,
+                @JsonProperty(value = "priority", defaultValue = "0.0") double priority) {
+            this.replace = replace != null ? ImmutableSet.copyOf(replace) : null;
+            this.biome = biome;
+            this.priority = priority;
+
+            this.minX = bounds.minX();
+            this.maxX = bounds.maxX();
+            this.minZ = bounds.minZ();
+            this.maxZ = bounds.maxZ();
+        }
+
+        @Override
+        public int compareTo(BiomeBoundingBox o) {
+            return -Double.compare(this.priority, o.priority);
+        }
+
+        @JsonGetter("bounds")
+        public Bounds2d bounds() {
+            return Bounds2d.of(this.minX, this.maxX, this.minZ, this.maxZ);
+        }
+    }
+}


### PR DESCRIPTION
- [x] Add the biome filter `UserOverrideBiomeFilter` from T++
- [x] Add a new constructor to `ChunkDataLoader` for initialisation via generator dataset and biome filters
- [x] Add such a constructor to `EarthBiomeProvider`
- [x] Add a constructor to `GeneratorDatasets` for initialisation via the dataset map and projection
- [x] Sync fork with recent changes made to the Biome system, which replaced the previous updated Biome system